### PR TITLE
fix: correct bun command in package manager tabs

### DIFF
--- a/src/components/ui/package-manager-tabs.tsx
+++ b/src/components/ui/package-manager-tabs.tsx
@@ -52,7 +52,7 @@ export function PackageManagerTabs({
         pnpm: "pnpm dlx",
         npm: "npx",
         yarn: "yarn",
-        bun: "bunx --bun",
+        bun: "bun x --bun",
       },
       add: {
         pnpm: "pnpm add",


### PR DESCRIPTION
### Feature description


![Capture](https://github.com/user-attachments/assets/cbf880bb-5e54-4bf8-a053-757a7196cf63)


Error: 

Running the command above results in an error or unexpected behavior because the command format does not align with the latest Tailwind v4, V3 update.

```bash
bunx --bun v3cn add discord
```
Solution

The correct command should be:

```bash
bun x --bun v3cn add discord
```


**similar isssue in diff UI libaray** 

https://github.com/shadcn-ui/ui/issues/6960#issuecomment-2740743126
https://github.com/magicuidesign/magicui/issues/562#issuecomment-2685909778