### PR TITLE
Fix: #25 Scrollbar on GitHub graph component 

### DIFF
--- a/src/app/docs/components/github-graph/page.tsx
+++ b/src/app/docs/components/github-graph/page.tsx
@@ -68,13 +68,12 @@ export default async function GithubGraphPage() {
             </p>
           </section>
 
-          <section className="overflow-y-scroll">
+          <section>
           <div className="w-full text-2xl font-semibold mb-4 flex justify-between items-center gap-2" id="playground">
              <span>Playground</span>
               <OpenInV0Button url="https://v3cn.vineet.pro/r/github-demo" />
             </div>
-            <div className="flex justify-center items-center bg-gray-200 dark:bg-gradient-to-br dark:from-zinc-900 dark:to-zinc-950 border border-gray-400 dark:border-zinc-700 rounded-lg max-md:max-w-[93vw] h-[300px] sm:h-[400px] md:h-[500px] overflow-hidden max-md:overflow-x-scroll">
-
+            <div className="flex justify-center items-center bg-gray-200 dark:bg-gradient-to-br dark:from-zinc-900 dark:to-zinc-950 border border-gray-400 dark:border-zinc-700 rounded-lg max-md:max-w-[93vw] h-[300px] sm:h-[400px] md:h-[500px] overflow-hidden">
               <DemoGithubGraph
                 username="VineeTagarwaL-code"
                 blockMargin={2}


### PR DESCRIPTION
This issue was due to the max-md:overflow-x-scroll class forcing that scroll.

# Testing
Tested the component on various screen sizes to ensure:
- The graph displays properly on all screen sizes
- No horizontal scrollbar appears
![V3CN - Components like never before _ V3CN - Google Chrome 31-03-2025 15_07_52](https://github.com/user-attachments/assets/0bc5415f-cb77-4a6c-8796-af7a0aae21dc)
